### PR TITLE
INBT-9430 | add UNACCENT as string_matching_operator value

### DIFF
--- a/lib/wice/columns/column_string.rb
+++ b/lib/wice/columns/column_string.rb
@@ -79,6 +79,8 @@ module Wice
 
         comparator = if string_matching_operator == 'CI_LIKE'
           " #{negation}  UPPER(#{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name}) LIKE  UPPER(?)"
+        elsif string_matching_operator == 'UNACCENT'
+          " #{negation}  UNACCENT(#{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name}) ILIKE  UNACCENT(?)"
         else
           " #{negation}  #{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name} #{string_matching_operator} ?"
         end


### PR DESCRIPTION
Use UNACCENT function to be able to do accent-insensitive comparison